### PR TITLE
50: Client Side to Enable Firebase Rules

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -291,7 +291,6 @@ export const fetchAdmins = () => async (dispatch) => {
     .get()
     .then((querySnapshot) => {
       const data = querySnapshot.docs.map((doc) => doc.data());
-      console.log(data)
       dispatch({ type: FETCH_ADMINS, payload: data });
     })
     .catch(function (error) {

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -286,10 +286,12 @@ export const chatDisconnect = () => async (dispatch) => {
 
 export const fetchAdmins = () => async (dispatch) => {
   database
-    .collection("admins")
+    .collection("users")
+    .where("admin", "==", true)
     .get()
     .then((querySnapshot) => {
       const data = querySnapshot.docs.map((doc) => doc.data());
+      console.log(data)
       dispatch({ type: FETCH_ADMINS, payload: data });
     })
     .catch(function (error) {

--- a/client/src/components/GoogleAuth.js
+++ b/client/src/components/GoogleAuth.js
@@ -1,40 +1,32 @@
 import React from "react";
 import { connect } from "react-redux";
 import { fetchProfile, awaitSignIn, signOut } from "../actions";
+import firebase from "firebase";
 
 class GoogleAuth extends React.Component {
+  provider = new firebase.auth.GoogleAuthProvider();
+
   componentDidUpdate(){
     if(this.props.rejectSignIn === true){
-      this.auth.signOut();
+      firebase.auth().signOut();
     }
   }
-  
+
   componentDidMount() {
-    window.gapi.load("client:auth2", () => {
-      window.gapi.client
-        .init({
-          clientId:
-            "434963010544-itr9jvms5cn5i6e4097458nrv17uv5me.apps.googleusercontent.com",
-          scope: "email"
-        })
-        .then(() => {
-          this.auth = window.gapi.auth2.getAuthInstance();
-          this.onAuthChange(this.auth.isSignedIn.get());
-          this.auth.isSignedIn.listen(this.onAuthChange);
-        });
-    });
+    firebase.auth().onAuthStateChanged(this.onAuthChange);
   }
-  onAuthChange = isSignedIn => {
-    if (isSignedIn) {
+
+  onAuthChange = user => {
+    if (user) {
       this.props.fetchProfile({
-        id: this.auth.currentUser.get().getId(), 
-        name: this.auth.currentUser.get().getBasicProfile().getName(), 
-        email: this.auth.currentUser.get().getBasicProfile().getEmail()
+        id: user.uid,
+        name: user.displayName,
+        email: user.email
       });
       this.props.awaitSignIn(
-        this.auth.currentUser.get().getId(), 
-        this.auth.currentUser.get().getBasicProfile().getName(), 
-        this.auth.currentUser.get().getBasicProfile().getEmail()
+        user.uid,
+        user.displayName,
+        user.email
       );
     } else {
       this.props.signOut();
@@ -42,11 +34,16 @@ class GoogleAuth extends React.Component {
   };
 
   onSignInClick = () => {
-    this.auth.signIn();
+    firebase
+      .auth()
+      .signInWithPopup(this.provider)
+      .catch(function(error) {
+        console.log(error);
+      });
   };
 
   onSignOutClick = () => {
-    this.auth.signOut();
+    firebase.auth().signOut();
   };
 
   render() {
@@ -54,9 +51,7 @@ class GoogleAuth extends React.Component {
   }
 
   renderAuthButton() {
-    if (this.props.isSignedIn === null) {
-      return null;
-    } else if (this.props.isSignedIn) {
+    if (this.props.isSignedIn) {
       return (
         <button onClick={this.onSignOutClick} className="ui red google button">
           <i className="google icon" />
@@ -75,8 +70,8 @@ class GoogleAuth extends React.Component {
 }
 
 const mapStateToProps = state => {
-  return { 
-    isSignedIn: state.auth.isSignedIn, 
+  return {
+    isSignedIn: state.auth.isSignedIn,
     rejectSignIn: state.auth.rejectSignIn
   };
 };

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -8,7 +8,7 @@ import Logo from "./logonobg.png";
 
 const Header = () => {
   return (
-    <div className="ui menu inverted" style={{ margin: "0px 0px 2px" }}>
+    <div className="ui menu inverted" style={{ margin: "0px 0px 2px", flex: "0 0 auto" }}>
       <div className="header item">
         <Link to="/">
           <img src={Logo} style={{ width: "100px" }}></img>

--- a/client/src/components/streams/StreamList.js
+++ b/client/src/components/streams/StreamList.js
@@ -87,7 +87,7 @@ class StreamList extends React.Component {
     } else if (this.props.admins !== undefined) {
       if (
         this.props.admins.filter(
-          (admin) => admin.adminid === this.props.currentUserId
+          (admin) => admin.userid === this.props.currentUserId
         ).length !== 0
       ) {
         return (


### PR DESCRIPTION
This replaces Google Sign-In with Firebase Authentication's Google sign-in.

This will enable us to create rules in the database, so that a user can only edit their own data.

Admins will be identified by a boolean attribute instead of using a collection with ids. This will make it possible to set up a rule in firebase that allows an admin to delete another user's stream.

Note: Once this gets merged, the rules still need to be created. This just enables us to actually create the rules.
Note 2: This will also make it so you can't login to your old account unfortunately, since the id that firebase gives us different from the Google Sign-In one.

Currently, anyone is allowed to read and write to our database, and it's easy to modify the client code to just delete everything as a result. If we plan on keeping the firebase up after the course then this needs to be done. If not, then it likely isn't an issue. The only problem I can see is that if the prof decides to run this app a year from now, it wont work if the firebase isn't up. I'm honestly not too sure how big of an issue this is.