### PR TITLE
65: Fix Firefox Crashing When Viewing Inactive Stream

### DIFF
--- a/client/src/components/streams/StreamShow.js
+++ b/client/src/components/streams/StreamShow.js
@@ -22,7 +22,7 @@ class StreamShow extends React.Component {
   }
 
   componentWillUnmount() {
-    this.player.destroy();
+    this.player.unload();
   }
 
   buildPlayer() {
@@ -36,12 +36,6 @@ class StreamShow extends React.Component {
     });
     this.player.attachMediaElement(this.videoRef.current);
     this.player.load();
-    const playPromise = this.player.play();
-    playPromise.catch((error) => {
-      // player.destroy() calls detachMediaElement which causes an AbortError in Firefox
-      // https://github.com/bilibili/flv.js/issues/532
-      this.player = null;
-    });
   }
 
   render() {

--- a/client/src/components/streams/StreamShow.js
+++ b/client/src/components/streams/StreamShow.js
@@ -36,6 +36,12 @@ class StreamShow extends React.Component {
     });
     this.player.attachMediaElement(this.videoRef.current);
     this.player.load();
+    const playPromise = this.player.play();
+    playPromise.catch((error) => {
+      // player.destroy() calls detachMediaElement which causes an AbortError in Firefox
+      // https://github.com/bilibili/flv.js/issues/532
+      this.player = null;
+    });
   }
 
   render() {


### PR DESCRIPTION
Firefox seems to be crashing when we return to the homepage from a dead stream.

When we call this.player.destroy, flv.js calls detachMediaElement, which sets the source url of the stream to ''. My guess is that Firefox is detecting the change in source, and is immediately fetching the new video from the new source, but playback at this point has already been aborted, so it throws an error which is never caught.

A quickfix is to use unload instead of destroy. It doesn't call detachMediaElement, so it doesn't error out. I'm not sure whether it has any adverse effects, but it lets us run through the demo script in Firefox and Chrome.